### PR TITLE
[PKG-4138] Initial build 2.14.6

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-MACOSX_DEPLOYMENT_TARGET:
-  - '10.12'  # [osx and x86]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,2 @@
-macos_min_version:  # [osx and x86_64]
-  - 10.13  # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - 10.13  # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
+  - 10.12  # [osx and x86]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+macos_min_version:  # [osx and x86_64]
+  - 10.13  # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+  - 10.13  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ build:
     - RUSTC_LOG=rustc_codegen_ssa::back::link=info  # [osx and x86_64]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
   number: 0
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
@@ -50,7 +51,7 @@ about:
     This package provides the core functionality for pydantic validation and serialization.
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: THIRDPARTY.yml
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,9 @@ source:
 
 build:
   script_env:
+    # on osx-64, we get an error from install_name_tool: changing install names or rpaths can't be redone for: <path> (for architecture x86_64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
+    # After some investigation, rustc doesn't seem to read our LDFLAGS
     - RUSTFLAGS=-C link-args=-headerpad_max_install_names  # [osx and x86_64]
-    - RUSTC_LOG=rustc_codegen_ssa::back::link=info  # [osx and x86_64]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python
     - maturin >=1,<2
     - typing-extensions  >=4.6.0,!=4.7.0
+    - wheel
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ about:
   description: |
     This package provides the core functionality for pydantic validation and serialization.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,9 @@ source:
   sha256: 1fd0c1d395372843fba13a51c28e3bb9d59bd7aebfeb17358ffaaa1e4dbbe948
 
 build:
+  script_env:
+    - RUSTFLAGS=-C link-args=-headerpad_max_install_names  # [osx and x86_64]
+    - RUSTC_LOG=rustc_codegen_ssa::back::link=info  # [osx and x86_64]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler("c") }}
+    - {{ compiler("cxx")}}  # [osx and x86]
     - {{ compiler("rust") }}
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.16.3" %}
+{% set version = "2.14.6" %}
 
 package:
   name: pydantic-core
@@ -6,24 +6,17 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pydantic-core/pydantic_core-{{ version }}.tar.gz
-  sha256: 1cac689f80a3abab2d3c0048b29eea5751114054f032a941a32de4c852c59cad
+  sha256: 1fd0c1d395372843fba13a51c28e3bb9d59bd7aebfeb17358ffaaa1e4dbbe948
 
 build:
   script:
-    # PyPy has weird sysconfigdata name
-    - rm -f $PREFIX/lib/pypy$PY_VER/_sysconfigdata.py  # [build_platform != target_platform and target_platform == "linux-ppc64le"]
-    - {{ PYTHON }} -m pip install . -vv
-    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - maturin >=1,<2                         # [build_platform != target_platform]
     - {{ compiler("c") }}
     - {{ compiler("rust") }}
-    - cargo-bundle-licenses
   host:
     - pip
     - python
@@ -45,7 +38,10 @@ test:
 about:
   home: https://github.com/pydantic/pydantic-core
   dev_url: https://github.com/pydantic/pydantic-core
+  doc_url: https://docs.pydantic.dev
   summary: Core validation logic for pydantic written in rust
+  description: |
+    This package provides the core functionality for pydantic validation and serialization.
   license: MIT
   license_file: LICENSE
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 requirements:
   build:
     - {{ compiler("c") }}
-    - {{ compiler("cxx")}}  # [osx and x86]
     - {{ compiler("rust") }}
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - python
     - maturin >=1,<2
     - typing-extensions  >=4.6.0,!=4.7.0
-    - wheel
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - python
     - maturin >=1,<2
     - typing-extensions  >=4.6.0,!=4.7.0
+    - wheel
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,13 +24,12 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("rust") }}
+    - cargo-bundle-licenses
   host:
     - pip
     - python
     - maturin >=1,<2
     - typing-extensions  >=4.6.0,!=4.7.0
-    - wheel
-    - cargo-bundle-licenses
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,9 @@ about:
     This package provides the core functionality for pydantic validation and serialization.
   license: MIT
   license_family: MIT
-  license_file: THIRDPARTY.yml
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - maturin >=1,<2
     - typing-extensions  >=4.6.0,!=4.7.0
     - wheel
+    - cargo-bundle-licenses
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
   host:
     - pip
     - python
-    - maturin 1.3.1
-    - typing-extensions  4.9.0
+    - maturin >=1,<2
+    - typing-extensions  >=4.6.0,!=4.7.0
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
   host:
     - pip
     - python
-    - maturin >=1,<2
-    - typing-extensions  >=4.6.0,!=4.7.0
+    - maturin 1.3.1
+    - typing-extensions  4.9.0
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0


### PR DESCRIPTION
pydantic-core 2.14.6

**Destination channel:** defaults

### Links

- [PKG-4138](https://anaconda.atlassian.net/browse/PKG-4138) 
- [Upstream repository](https://github.com/pydantic/pydantic-core)

### Explanation of changes:

- Forced `-headerpad_max_install_names` on osx-64 to fix a build failure. 
- Several test dependencies are not available on defaults, so tests are omitted.


[PKG-4138]: https://anaconda.atlassian.net/browse/PKG-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ