### PR TITLE
Update 2.21.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.14.6" %}
+{% set version = "2.21.0" %}
 
 package:
   name: pydantic-core
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pydantic-core/pydantic_core-{{ version }}.tar.gz
-  sha256: 1fd0c1d395372843fba13a51c28e3bb9d59bd7aebfeb17358ffaaa1e4dbbe948
+  sha256: 79c747f9916e5b6cb588dfd994d9ac15a93e43eb07467d9e6f24d892c176bbf5
 
 build:
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
   number: 0
   missing_dso_whitelist:  # [s390x]
-    - $RPATH/ld64.so.1    # [s390x] 
+    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
   number: 0
   missing_dso_whitelist:  # [s390x]
-    - $RPATH/ld64.so.1    # [s390x]
+    - $RPATH/ld64.so.1    # [s390x] 
 
 requirements:
   build:


### PR DESCRIPTION
## ☆Pydantic-core 2.21.0 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5245)
[Upstream](https://github.com/pydantic/pydantic-core/tree/main)
# Changes
- Updated version number and `sha256`
- Skip to `python` versions less than 3.8