### PR TITLE
Pydantic-core V2.20.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.21.0" %}
+{% set version = "2.20.1" %}
 
 package:
   name: pydantic-core
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pydantic-core/pydantic_core-{{ version }}.tar.gz
-  sha256: 79c747f9916e5b6cb588dfd994d9ac15a93e43eb07467d9e6f24d892c176bbf5
+  sha256: 26ca695eeee5f9f1aeeb211ffc12f10bcb6f71e2989988fda61dabd65db878d4
 
 build:
   script_env:


### PR DESCRIPTION
## ☆Pydantic-core 2.20.1 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5530)
[Upstream](https://github.com/pydantic/pydantic-core/tree/main)
# Changes
- Updated version number and `sha256`
