### PR TITLE
Pydantic-core 2.20.1 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 
 # Ignore all files and folders in root
 *
-!/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: False

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,11 +30,11 @@ requirements:
     - python
     - maturin >=1,<2
     - typing-extensions  >=4.6.0,!=4.7.0
+    - wheel
+
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0
-    - wheel
-    - setuptools
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("rust") }}
-    - cargo-bundle-licenses
+    - cargo-bundle-licenses 0.5.0
   host:
     - pip
     - python
@@ -33,6 +33,8 @@ requirements:
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0
+    - wheel
+    - setuptools
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - python
     - maturin >=1,<2
     - typing-extensions  >=4.6.0,!=4.7.0
-    - wheel
 
   run:
     - python


### PR DESCRIPTION
This is an older version of Pydantic-core, which is required for [Pydantic's](https://anaconda.atlassian.net/browse/PKG-5245) most recent update.

## ☆Pydantic-core 2.20.1 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5530)
[Upstream](https://github.com/pydantic/pydantic-core/tree/main)

Changes
Updated version number and sha256