### PR TITLE
Update pydantic-core to 2.27.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.21.0" %}
+{% set version = "2.27.1" %}
 
 package:
   name: pydantic-core
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pydantic-core/pydantic_core-{{ version }}.tar.gz
-  sha256: 79c747f9916e5b6cb588dfd994d9ac15a93e43eb07467d9e6f24d892c176bbf5
+  sha256: 62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235
 
 build:
   script_env:
@@ -16,7 +16,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-  number: 1
+  number: 0
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - pip
     - python
     - maturin >=1,<2
-    - typing-extensions  >=4.6.0,!=4.7.0
+    - typing-extensions >=4.6.0,!=4.7.0
   run:
     - python
     - typing-extensions >=4.6.0,!=4.7.0


### PR DESCRIPTION
pydantic-core 2.27.1

**Destination channel:** {defaults}

### Links

- [PKG-6222](https://anaconda.atlassian.net/browse/PKG-6222) 
- [Upstream repository](https://github.com/pydantic/pydantic-core)
- Relevant dependency PRs:
  - [`typing-extensions 4.12.2`](https://github.com/AnacondaRecipes/typing_extensions-feedstock/pull/20)
  - [`pydantic-core 2.27.1`](https://github.com/AnacondaRecipes/pydantic-core-feedstock/pull/7)
  - [`pydantic 2.10.3`](https://github.com/AnacondaRecipes/pydantic-feedstock/pull/16)
  - [`menuinst 2.2.0`](url) with py3.13 support for `conda`

### Explanation of changes:

- ...


[PKG-6222]: https://anaconda.atlassian.net/browse/PKG-6222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ