### PR TITLE
PKG-9336: pydantic-core 2.39.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/typing_extensions-feedstock/pr28/c67d484
+  - https://staging.continuum.io/prefect/fs/maturin-feedstock/pr14/17feb23

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/typing_extensions-feedstock/pr28/c67d484
-  - https://staging.continuum.io/prefect/fs/maturin-feedstock/pr14/17feb23

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,16 @@
 # Keep the version in sync with pydantic-feedstock because the latest version can be incompatible.
-{% set version = "2.33.2" %}
+{% set name = "pydantic-core" %}
+{% set version = "2.39.0" %}
 
 package:
-  name: pydantic-core
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/p/pydantic-core/pydantic_core-{{ version }}.tar.gz
-  sha256: 7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: b890a3990bd55ba5dab17fb6ae80eb25bb33e2f5b462da386562e7a168dd02de
 
 build:
-  script_env:
-    # on osx-64, we get an error from install_name_tool: changing install names or rpaths can't be redone for: <path> (for architecture x86_64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
-    # After some investigation, rustc doesn't seem to read our LDFLAGS
-    - RUSTFLAGS=-C link-args=-headerpad_max_install_names  # [osx and x86_64]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
@@ -22,17 +19,17 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler("c") }}
     - {{ compiler("rust") }}
     - cargo-bundle-licenses
   host:
     - pip
     - python
-    - typing-extensions >=4.6.0,!=4.7.0
-    - maturin >=1,<2
+    - maturin >=1.9,<2
   run:
     - python
-    - typing-extensions >=4.6.0,!=4.7.0
+    - typing-extensions >=4.14.1
 
 test:
   imports:


### PR DESCRIPTION
pydantic-core 2.39.0

**Destination channel:** defaults

### Links

- [PKG-9336](https://anaconda.atlassian.net/browse/PKG-9336) 
- [Upstream repository](https://github.com/pydantic/pydantic-core/tree/v2.39.0)

### Explanation of changes:

- new version update


[PKG-9336]: https://anaconda.atlassian.net/browse/PKG-9336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ