### PR TITLE
pydantic-core 2.41.5 Rebuild for Python 3.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
   - 10.12  # [osx and x86]
+
+c_compiler_version:
+  - 11.2.0                 # [linux]
+cxx_compiler_version:
+  - 11.2.0                 # [linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86]
-  - 10.12  # [osx and x86]
-
 c_compiler_version:
   - 11.2.0                 # [linux]
 cxx_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-  number: 0
+  number: 1
   skip: true  # [py<39]
 
 requirements:


### PR DESCRIPTION
pydantic-core 2.41.5 

**Destination channel:** Defaults

### Links

- [PKG-10980]
- dev_url:        https://github.com/pydantic/pydantic-core/tree/v2.41.5
- conda_forge:    https://github.com/conda-forge/pydantic-core-feedstock
- pypi:           https://pypi.org/project/pydantic-core/2.41.5
- pypi inspector: https://inspector.pypi.io/project/pydantic-core/2.41.5

### Explanation of changes:

- Rebuild for Python 3.14


[PKG-10980]: https://anaconda.atlassian.net/browse/PKG-10980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ