### PR TITLE
pydantic-core 2.46.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-  skip: true  # [py<310]
+  skip: true  # [py<39]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     - typing-extensions >=4.14.1
 
 #E   pytest.PytestUnknownMarkWarning: Unknown pytest.mark.thread_unsafe - is this a typo?
+# Instead of skipping those (since no pytest-run-parallel), we'll downgrade that single
+# error back to warning status (warning-as-error).
 {% set ignored_tests = [
   "--ignore=tests/test_docstrings.py",
   "--ignore=tests/test_hypothesis.py",
@@ -49,7 +51,8 @@ test:
   commands:
     - pip check
     - python -c "from pydantic_core import PydanticUndefinedType"
-    - pytest -v {{ ignored_tests | join(" ")}}
+    # downgrade back to warning severity (error as warning) instead of skipping ignored_tests (comment above).
+    - pytest -vv -W default::pytest.PytestUnknownMarkWarning
   requires:
     - pip
     - pytest
@@ -59,6 +62,7 @@ test:
     - pytest-benchmark
     - pytest-timeout
     - pytest-mock
+    - inline-snapshot
 
 about:
   home: https://github.com/pydantic

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,16 +66,15 @@ test:
 
 about:
   home: https://github.com/pydantic
-  dev_url: https://github.com/pydantic/pydantic/tree/main/pydantic-core
-  doc_url: https://docs.pydantic.dev
   summary: Core validation logic for pydantic written in rust
-  description: |
-    This package provides the core functionality for pydantic validation and serialization.
+  description: This package provides the core functionality for pydantic validation and serialization.
   license: MIT
   license_family: MIT
   license_file:
     - LICENSE
     - THIRDPARTY.yml
+  dev_url: https://github.com/pydantic/pydantic/tree/main/pydantic-core
+  doc_url: https://pydantic.dev/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # Keep the version in sync with pydantic-feedstock because the latest version can be incompatible.
 {% set name = "pydantic-core" %}
-{% set version = "2.42.0" %}
+{% set version = "2.46.2" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 34068adadf673c872f01265fa17ec00073e99d7f53f6d499bdfae652f330b3d2
+  sha256: 37bb079f9ee3f1a519392b73fda2a96379b31f2013c6b467fe693e7f2987f596
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,8 +61,8 @@ test:
     - pytest-mock
 
 about:
-  home: https://github.com/pydantic/pydantic-core
-  dev_url: https://github.com/pydantic/pydantic-core
+  home: https://github.com/pydantic
+  dev_url: https://github.com/pydantic/pydantic/tree/main/pydantic-core
   doc_url: https://docs.pydantic.dev
   summary: Core validation logic for pydantic written in rust
   description: |


### PR DESCRIPTION
pydantic-core 2.46.2 

**Destination channel:** Defaults

### Links

- [PKG-13760]
- dev_url:        https://github.com/pydantic/pydantic-core
- conda_forge:    https://github.com/conda-forge/pydantic-core-feedstock
- pypi:           https://pypi.org/project/pydantic-core/2.46.2
- pypi inspector: https://inspector.pypi.io/project/pydantic-core/2.46.2

### Explanation of changes:

- new version number


[PKG-13760]: https://anaconda.atlassian.net/browse/PKG-13760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ